### PR TITLE
fix: Fixed more cases that cause crashes

### DIFF
--- a/Audio/src/Audio.cs
+++ b/Audio/src/Audio.cs
@@ -30,7 +30,7 @@ namespace Audio;
 
 [PluginMetadata(
   Id = "Audio", 
-  Version = "1.0.3", 
+  Version = "1.0.4", 
   Name = "Audio", 
   Author = "samyyc", 
   Description = "A high performance VoIP audio lib for swiftlys2."

--- a/Audio/src/AudioChannel.cs
+++ b/Audio/src/AudioChannel.cs
@@ -62,18 +62,22 @@ public class AudioChannel : IAudioChannelController, IAudioChannel, IDisposable 
   public bool HasFrame(int slot)
   {
     ThrowIfDisposed();
-    return Source != null && !IsPaused[slot] && !IsMuted[slot] && Source.HasFrame(Cursors[slot]);
+    var source = Source;
+    return source != null && !IsPaused[slot] && !IsMuted[slot] && source.HasFrame(Cursors[slot]);
   }
 
   public ReadOnlySpan<float> GetFrame(int slot) {
     ThrowIfDisposed();
-    return Source!.GetFrame(Cursors[slot]);
+    var source = Source;
+    if (source == null) return ReadOnlySpan<float>.Empty;
+    return source.GetFrame(Cursors[slot]);
   }
 
   public void NextFrame() {
     ThrowIfDisposed();
+    var source = Source;
     for (int i = 0; i < AudioConstants.MaxPlayers; i++) {
-      if (!IsPaused[i] && Source != null && Source.HasFrame(i+1)) {
+      if (!IsPaused[i] && source != null && source.HasFrame(Cursors[i] + 1)) {
         Cursors[i] += 1;
       }
     }

--- a/Audio/src/AudioMainloop.cs
+++ b/Audio/src/AudioMainloop.cs
@@ -103,6 +103,7 @@ public class AudioMainloop : IDisposable {
           {
             if (player is not { IsValid: true }) continue;
             var i = player.PlayerID;
+            if ((uint)i >= AudioConstants.MaxPlayers) continue;
             if (!audioManager.HasFrame(i)) continue;
             if (offsets[player.PlayerID] is null) offsets[player.PlayerID] = new List<int>();
             var lastOffset = offsets[i].Count == 0 ? 0 : offsets[i].Last();
@@ -121,8 +122,9 @@ public class AudioMainloop : IDisposable {
 
         foreach (var player in allPlayers)
         {
-          if (player is not { IsValid: true} || offsets[player.PlayerID] is null) continue; 
+          if (player is not { IsValid: true}) continue;
           var i = player.PlayerID;
+          if ((uint)i >= AudioConstants.MaxPlayers || offsets[i] is null) continue;
 
           var msg = Core.NetMessage.Create<CSVCMsg_VoiceData>();
 

--- a/Audio/src/AudioManager.cs
+++ b/Audio/src/AudioManager.cs
@@ -25,9 +25,11 @@ using ZLinq.Simd;
 namespace Audio;
 
 public class AudioManager : IDisposable {
-  private List<AudioChannel> Channels { get; set; } = new();
-
-  private List<IAudioChannel> CustomChannels { get; set; } = new();
+  private readonly object _channelsLock = new();
+  private readonly List<AudioChannel> _channelsList = new();
+  private readonly List<IAudioChannel> _customChannelsList = new();
+  private volatile AudioChannel[] _channels = [];
+  private volatile IAudioChannel[] _customChannels = [];
 
   private OpusEncoder[] Encoders { get; set; } = new OpusEncoder[AudioConstants.MaxPlayers];
   private float[] CurrentFrame { get; set; } = new float[AudioConstants.FrameSize];
@@ -73,63 +75,89 @@ public class AudioManager : IDisposable {
 
 
   public void Dispose() {
+    AudioChannel[] channels;
+    IAudioChannel[] customChannels;
+    lock (_channelsLock) {
+      channels = _channels;
+      customChannels = _customChannels;
+      _channelsList.Clear();
+      _customChannelsList.Clear();
+      _channels = [];
+      _customChannels = [];
+    }
     foreach (var encoder in Encoders) {
       encoder.Dispose();
     }
-    foreach (var channel in Channels) {
+    foreach (var channel in channels) {
       channel.Dispose();
     }
-    foreach (var channel in CustomChannels) {
+    foreach (var channel in customChannels) {
       channel.Dispose();
     }
-    CustomChannels.Clear();
-    Channels.Clear();
   }
 
   public AudioChannel UseChannel(string id) {
-    if (Channels.Any(channel => channel.Id == id)) {
-      return Channels.First(channel => channel.Id == id);
+    lock (_channelsLock) {
+      var existing = _channelsList.FirstOrDefault(channel => channel.Id == id);
+      if (existing != null) return existing;
+      var newChannel = new AudioChannel(id);
+      _channelsList.Add(newChannel);
+      _channels = [.. _channelsList];
+      newChannel.OnOpusResetRequested += OpusReset;
+      return newChannel;
     }
-    var newChannel = new AudioChannel(id);
-    Channels.Add(newChannel);
-    newChannel.OnOpusResetRequested += OpusReset;
-    return newChannel;
   }
 
   public void AddCustomChannel(IAudioChannel channel) {
-    CustomChannels.Add(channel);
+    lock (_channelsLock) {
+      _customChannelsList.Add(channel);
+      _customChannels = [.. _customChannelsList];
+    }
     channel.OnOpusResetRequested += OpusReset;
   }
 
   public void RemoveCustomChannel(IAudioChannel channel) {
     channel.OnOpusResetRequested -= OpusReset;
-    CustomChannels.Remove(channel);
+    lock (_channelsLock) {
+      _customChannelsList.Remove(channel);
+      _customChannels = [.. _customChannelsList];
+    }
   }
 
   public bool HasFrame(int slot) {
-    return Channels.Any(channel => channel.HasFrame(slot)) || CustomChannels.Any(channel => channel.HasFrame(slot));
+    var channels = _channels;
+    var customChannels = _customChannels;
+    return channels.Any(channel => channel.HasFrame(slot)) || customChannels.Any(channel => channel.HasFrame(slot));
   }
 
   public void NextFrame() {
-    foreach (var channel in Channels) {
+    var channels = _channels;
+    var customChannels = _customChannels;
+    foreach (var channel in channels) {
       channel.NextFrame();
     }
-    foreach (var channel in CustomChannels) {
+    foreach (var channel in customChannels) {
       channel.NextFrame();
     }
   }
 
   public ReadOnlySpan<float> GetFrame(int slot) {
     ResetCurrentFrame();
-    foreach (var channel in Channels)
+    var channels = _channels;
+    var customChannels = _customChannels;
+    foreach (var channel in channels)
     {
       if (channel.HasFrame(slot)) {
-        MixFrames(CurrentFrame.AsSpan(), channel.GetFrame(slot), channel.GetVolume(slot));
+        var frame = channel.GetFrame(slot);
+        if (!frame.IsEmpty)
+          MixFrames(CurrentFrame.AsSpan(), frame, channel.GetVolume(slot));
       }
     }
-    foreach (var channel in CustomChannels) {
+    foreach (var channel in customChannels) {
       if (channel.HasFrame(slot)) {
-        MixFrames(CurrentFrame.AsSpan(), channel.GetFrame(slot), 1.0f);
+        var frame = channel.GetFrame(slot);
+        if (!frame.IsEmpty)
+          MixFrames(CurrentFrame.AsSpan(), frame, 1.0f);
       }
     }
     return CurrentFrame.AsSpan();


### PR DESCRIPTION
Fixes a server crash (segfault) originating from `AudioManager.GetFrame` on the thread pool worker thread, traced via `managedtrace.txt`.

### Root causes & fixes

**Thread-unsafe channel collections (`AudioManager.cs`)**
`Channels` and `CustomChannels` were plain `List<T>` modified on the game thread while iterated on the timer thread. Replaced with a copy-on-write pattern: writes lock and rebuild a volatile array snapshot; reads take a lock-free local reference.

**Cursor advancement bug (`AudioChannel.cs`)**
`NextFrame()` checked `Source.HasFrame(i+1)` (player index) instead of `Source.HasFrame(Cursors[i]+1)` (cursor position). This caused cursors to increment unbounded past the audio data, eventually producing out-of-bounds memory access in the native Opus encoder.

**TOCTOU race on `Source` (`AudioChannel.cs`)**
`HasFrame`/`GetFrame`/`NextFrame` each accessed `Source` multiple times without a local capture, allowing a null dereference if another thread set the source to null between checks. Now captured to a local variable.

**Missing PlayerID bounds check (`AudioMainloop.cs`)**
Added `(uint)i >= MaxPlayers` guard to prevent index-out-of-range on the 64-element per-player arrays.